### PR TITLE
Bug 1218913 - added missing type entries to schemas

### DIFF
--- a/schemas/constants.js
+++ b/schemas/constants.js
@@ -20,6 +20,7 @@ module.exports = {
   // Message version numbers
   "message-version": {
     "description":  "Message version",
+    "type":         "integer",
     "enum":         [1]
   },
 


### PR DESCRIPTION
"integer" seems the correct type according to http://json-schema.org/latest/json-schema-core.html#anchor8
