### PR TITLE
actually log errors when they occur

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -105,7 +105,7 @@ if (!module.parent) {
   launch(profile).then(function() {
     debug("Launched server successfully");
   }).catch(function(err) {
-    debug("Failed to start server, err: %s, as JSON: %j", err, err, err.stack);
+    console.log("Failed to start server, err: %s, as JSON: %j", err, err, err.stack);
     // If we didn't launch the server we should crash
     process.exit(1);
   });


### PR DESCRIPTION
Without this, running `babel-node bin/server.js test` without proper credentials just returns you to the prompt with no message.
