### PR TITLE
204 response changed to use res.reply

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -80,7 +80,7 @@ builder.declare({
   }
 
   // Return 204
-  res.status(204).send();
+  res.reply();
 });
 
 builder.declare({


### PR DESCRIPTION
Fixes [bugzilla.mozilla.com#1400999](https://bugzilla.mozilla.org/show_bug.cgi?id=1400999)

Continuation of [taskcluster-lib-api#145](https://github.com/taskcluster/taskcluster-lib-api/pull/145)